### PR TITLE
Add /health Endpoint for Health Check

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -49,8 +49,15 @@ sudo bash -c "echo '127.0.0.1    cluster-registry' >> /etc/hosts"
 
 Tag `recommendations:1.0` as `cluster-registry:5000/recommendations:1.0` and push it to the local registry:
 
+Tag:
+
 ```bash
 docker tag recommendations:1.0 cluster-registry:5000/recommendations:1.0
+```
+
+Push:
+
+```bash
 docker push cluster-registry:5000/recommendations:1.0
 ```
 

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -38,3 +38,17 @@ spec:
           requests:
             cpu: "0.10"
             memory: "32Mi"
+        # Liveness Probe: Used to check if the application is alive. If the probe fails, Kubernetes will automatically restart the container.
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        # Readiness Probe: Used to check if the application is ready to receive traffic. If the probe fails, the Pod will be marked as not ready and will not receive traffic.
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10

--- a/service/routes.py
+++ b/service/routes.py
@@ -362,3 +362,10 @@ def check_content_type(content_type) -> None:
         status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
         f"Content-Type must be {content_type}",
     )
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    """Health check endpoint"""
+    app.logger.info("Health check endpoint called")
+    return jsonify({"status": "OK"}), status.HTTP_200_OK

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -716,8 +716,7 @@ class TestYourResourceService(TestCase):
         data = response.get_json()
         self.assertIn("was not found", data["message"])
 
-        # ----------------------------------------------------------
-
+    # ----------------------------------------------------------
     # TEST ACTIONS - DISLIKE A RECOMMENDATION
     # ----------------------------------------------------------
     def test_dislike_a_recommendation(self):
@@ -742,3 +741,10 @@ class TestYourResourceService(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         data = response.get_json()
         self.assertIn("was not found", data["message"])
+
+    def test_health_endpoint(self):
+        """It should return a 200_OK response from the /health endpoint"""
+        response = self.client.get("/health")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertEqual(data["status"], "OK")


### PR DESCRIPTION
**Description**

It adds a `/health` endpoint. The endpoint provides a simple JSON response indicating the health status of the service, allowing Kubernetes to monitor if the service is running properly.

**Implementation Details**

- `/health` Endpoint:
    1. Added a new `/health` route in `service/routes.py`.
    2. The `/health` endpoint returns a JSON response {"status": "OK"} with an HTTP status code 200_OK.
    3. This endpoint is intended for use by Kubernetes liveness and readiness probes to check the service's health status.
- Kubernetes Health Probes:
   1. Liveness Probe: Checks if the app is alive; restarts the container if it fails.
       - Path: `/health`, Port: 8080
       - Delay: 15s, Interval: 20s
   2. Readiness Probe: Checks if the app is ready to receive traffic; marks the Pod as unready if it fails.
       - Path: `/health`, Port: 8080
       - Delay: 5s, Interval: 10s

**Acceptance Criteria**

- [x]  The `/health` endpoint returns {"status": "OK"}.
- [x]  The HTTP status code is 200_OK.
- [x]  Liveness and readiness probes are configured in deployment.yaml to use the /health endpoint.

**Testing**

1. Manually tested the `/health` endpoint to verify it returns the correct JSON response and status code.
2. Automated tests added in `tests/test_routes.py` to ensure the `/health` endpoint behaves as expected.
3. Verified the Kubernetes probes work as expected by observing the Pod behavior during testing.
