### PR TITLE
Add PostgreSQL Deployment for k8s

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -92,7 +92,7 @@ kns lab
 Apply the Kubernetes manifests in the `k8s` folder to deploy the `recommendations` application:
 
 ```bash
-kubectl apply -f k8s/
+kubectl apply -f k8s/ --recursive
 ```
 
 To check the status of all resources in the `default` namespace and confirm the Pods are running:
@@ -122,7 +122,7 @@ Replace `<pod-name>` with the actual name of your Pod.
 To remove all resources associated with the application, run:
 
 ```bash
-kubectl delete -f k8s/
+kubectl delete -f k8s/ --recursive
 ```
 
 ---

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -5,12 +5,12 @@ metadata:
   labels:
     app: recommendations
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 2
-      maxUnavailable: 0  
+      maxSurge: 0%
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: recommendations
@@ -23,32 +23,28 @@ spec:
       containers:
       - name: recommendations
         image: cluster-registry:5000/recommendations:1.0
-        # image: recommendations
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
           protocol: TCP
         env:
-        - name: DATABASE_URI
-          value: "sqlite:///:memory:"  # Use an in-memory SQLite database as a temporary database; PostgreSQL will be completed in the next story.
+          - name: RETRY_COUNT
+            value: "10"
+          - name: DATABASE_URI
+            valueFrom:
+              secretKeyRef:
+                name: postgres-creds
+                key: database_uri
+        readinessProbe:
+          initialDelaySeconds: 10
+          periodSeconds: 60
+          httpGet:
+            path: /health
+            port: 8080
         resources:
           limits:
+            cpu: "0.50"
+            memory: "128Mi"
+          requests:
             cpu: "0.25"
             memory: "64Mi"
-          requests:
-            cpu: "0.10"
-            memory: "32Mi"
-        # Liveness Probe: Used to check if the application is alive. If the probe fails, Kubernetes will automatically restart the container.
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8080
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        # Readiness Probe: Used to check if the application is ready to receive traffic. If the probe fails, the Pod will be marked as not ready and will not receive traffic.
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 10

--- a/k8s/postgresql/configmap.yaml
+++ b/k8s/postgresql/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+data:
+  postgres_user: postgres
+  postgres_db: recommendations

--- a/k8s/postgresql/pvc.yaml
+++ b/k8s/postgresql/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/postgresql/secret.yaml
+++ b/k8s/postgresql/secret.yaml
@@ -1,0 +1,16 @@
+# This secret can also be created from the command line using environment variables
+#
+# export DATABASE_URI='postgresql://<place-url-to-database-here>'
+# export POSTGRES_PASSWORD='<place-password-here>'
+#
+# kubectl create secret generic postgres-creds \
+#     --from-literal=password=$POSTGRES_PASSWORD
+#     --from-literal=database_uri=$DATABASE_URI
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-creds
+data:
+  password: cGdzM2NyM3Q=
+  database_uri: cG9zdGdyZXNxbCtwc3ljb3BnOi8vcG9zdGdyZXM6cGdzM2NyM3RAcG9zdGdyZXM6NTQzMi9wb3N0Z3Jlcw==

--- a/k8s/postgresql/service.yaml
+++ b/k8s/postgresql/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  type: ClusterIP
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/k8s/postgresql/statefulset.yaml
+++ b/k8s/postgresql/statefulset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  serviceName: "postgres"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-creds
+                  key: password
+            - name: POSTGRES_USER
+              valueFrom:
+                  configMapKeyRef:
+                    name: postgres-config
+                    key: postgres_user
+            - name: POSTGRES_DB
+              valueFrom:
+                  configMapKeyRef:
+                    name: postgres-config
+                    key: postgres_db
+          volumeMounts:
+          - name: postgres-storage
+            mountPath: /var/lib/postgresql
+          resources:
+            limits:
+              cpu: "0.50"
+              memory: "128Mi"
+            requests:
+              cpu: "0.25"
+              memory: "64Mi"
+      volumes:
+      - name: postgres-storage
+        persistentVolumeClaim:
+          claimName: postgres-pvc
+        # emptyDir: {}

--- a/k8s/pv.yaml
+++ b/k8s/pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv0001
+spec:
+  capacity:
+    storage: 1Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Recycle
+  hostPath:
+    path: /data/pv0001
+  # storageClassName: "default"


### PR DESCRIPTION
**Description**
This pull request implements the creation of a `postgresql/` folder under the `k8s/` directory to organize the YAML configuration files for deploying PostgreSQL in Kubernetes as a StatefulSet. 

The following files are included in the `k8s/postgresql/` folder:

- `configmap.yaml`: Contains environment configurations for PostgreSQL (e.g., database name and user).
- `pvc.yaml`: Defines PersistentVolumeClaim for PostgreSQL storage.
- `secret.yaml`: Stores sensitive credentials such as the database password and connection URI.
- `service.yaml`: Exposes PostgreSQL as a ClusterIP service within the Kubernetes cluster.
- `statefulset.yaml`: Defines the StatefulSet for deploying PostgreSQL with persistent storage.

Additionally, this PR updates:

- k8s/deployment.yaml: Replaces the in-memory SQLite database with PostgreSQL by updating the DATABASE_URI environment variable to use the Secret.
- k8s/README.md: Modify instructions.

**Acceptance Criteria**

- [x] A new `k8s/postgresql/` folder exists under `k8s/`.
- [x] The folder contains all necessary YAML files for deploying PostgreSQL as a StatefulSet.
- [x] `k8s/deployment.yaml` is updated to use PostgreSQL as the database.
- [x] The application successfully connects to PostgreSQL when deployed.

**Testing**

- Confirmed the application connects to PostgreSQL successfully and stores data persistently.
