### PR TITLE
Update imagePullPolicy to Always

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
       - name: recommendations
         image: cluster-registry:5000/recommendations:1.0
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         ports:
         - containerPort: 8080
           protocol: TCP


### PR DESCRIPTION
Description:
This PR updates the `imagePullPolicy` in the `deployment.yaml` for the `recommendations` service. The change ensures that the latest image is always pulled from the registry during deployments, which helps avoid issues with outdated cached images.

Changes:
- Changed `imagePullPolicy` from `IfNotPresent` to `Always`.